### PR TITLE
Replace Author URL based on User input

### DIFF
--- a/templates/default-comment-template.html
+++ b/templates/default-comment-template.html
@@ -4,7 +4,7 @@
 			<footer class="comment-meta">
 				<div class="comment-author vcard">
 					<img src="AVATAR_URL" alt="" class="avatar avatar-AVATAR_SIZE" width="AVATAR_SIZE" height="AVATAR_SIZE"/>
-					<b class="fn"><a href="#" rel="external nofollow" class="url">COMMENT_AUTHOR</a></b>
+					<b class="fn"><a href="COMMENT_AUTHOR_URL" rel="external nofollow" class="url">COMMENT_AUTHOR</a></b>
 					<span class="says">says:</span>
 				</div>
 				<div class="comment-metadata">


### PR DESCRIPTION
Author URL was not replaced when using Child theme. This is because the literal to be replaced was unavailable and a '#' was placed in place of the literal. This has been fixed by modifying the default template.